### PR TITLE
#BugFix.  В некоторых случаях в $response попадает массив, а не объект. …

### DIFF
--- a/src/Exceptions/ApiResponseException.php
+++ b/src/Exceptions/ApiResponseException.php
@@ -16,7 +16,7 @@ class ApiResponseException extends RequestFailedException{
     public function __construct($request, $response)
     {
         parent::__construct($request, $response);
-        $error = $response->errors[0];
+        $error = is_array($response) ? $response[0]->errors[0] : $response->errors[0];
         $this->code = $error->code;
         $this->errorText = $error->error;
         $this->moreInfo = $error->moreInfo;


### PR DESCRIPTION
…(например при неправильном формате поля - https://yadi.sk/d/qi043t3y3T6mo5). Добавил условие, чтобы скрипт не падал с неизвестной ошибкой.