### PR TITLE
Добавь пожалуйста 303 ошибку в HTTP_CODE_SUCCESS

### DIFF
--- a/src/Components/Http/MoySkladHttpClient.php
+++ b/src/Components/Http/MoySkladHttpClient.php
@@ -15,7 +15,7 @@ class MoySkladHttpClient{
         METHOD_POST = "POST",
         METHOD_PUT = "PUT",
         METHOD_DELETE = "DELETE",
-        HTTP_CODE_SUCCESS = [200, 201, 307];
+        HTTP_CODE_SUCCESS = [200, 201, 307, 303];
 
     private $preRequestSleepTime = 200;
 


### PR DESCRIPTION
Если скачивать документ из шаблона, то ответ приходит с 303 статусом, и расценивается как ошибка, хотя тело ответа содержит ссылку. $customerOrder->createExport($templateList); не работает, пока не добавишь 303 статус в массив HTTP_CODE_SUCCESS. Спасибо